### PR TITLE
[mesh_gre] Support for gretaps between hosts

### DIFF
--- a/roles/mesh_gre/handlers/main.yml
+++ b/roles/mesh_gre/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: restart mesh_gre tunnel
+  shell: |
+    {% for hostname in mesh_gre.peers %}
+    ifdown mg-{{ hostname }} || true
+    ip link set down mg-{{ hostname }} && ip link del mg-{{ hostname }} || true
+    ifdown mg-{{ hostname }}
+    {% endfor %}
+

--- a/roles/mesh_gre/handlers/main.yml
+++ b/roles/mesh_gre/handlers/main.yml
@@ -4,6 +4,6 @@
     {% for hostname in mesh_gre.peers %}
     ifdown mg-{{ hostname }} || true
     ip link set down mg-{{ hostname }} && ip link del mg-{{ hostname }} || true
-    ifdown mg-{{ hostname }}
+    ifup mg-{{ hostname }}
     {% endfor %}
 

--- a/roles/mesh_gre/tasks/main.yml
+++ b/roles/mesh_gre/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Ensure gre tunnel is in place
+  template:
+    src: "etc/network/interfaces.d/mesh_gre.j2"
+    dest: "/etc/network/interfaces.d/mesh-gre"
+  notify:
+    - restart mesh_gre tunnel
+  tags: mesh
+

--- a/roles/mesh_gre/templates/etc/network/interfaces.d/mesh_gre.j2
+++ b/roles/mesh_gre/templates/etc/network/interfaces.d/mesh_gre.j2
@@ -1,0 +1,13 @@
+{% for gateway_name in mesh_gre.peers %}
+{% if inventory_hostname in hostvars[gateway_name].mesh_gre.peers %}
+
+auto mg-{{ gateway_name }}
+iface mg-{{ gateway_name }} inet manual
+  pre-up ip link add $IFACE type gretap local {{ interface.wan.address.ipv4 | ipaddr('address') }} remote {{ hostvars[gateway_name].interface.wan.address.ipv4 | ipaddr('address') }} dev {{ interface.wan.name }}
+  pre-up ip link set $IFACE up
+  post-up /usr/sbin/batctl -m bat-{{ site.code }} if add $IFACE ||:
+  pre-down /usr/sbin/batctl -m bat-{{ site.code }} if del $IFACE ||:
+  post-down ip link del $IFACE
+
+{% endif %}
+{% endfor %}

--- a/roles/mesh_gre/templates/etc/network/interfaces.d/mesh_gre.j2
+++ b/roles/mesh_gre/templates/etc/network/interfaces.d/mesh_gre.j2
@@ -4,6 +4,7 @@
 auto mg-{{ gateway_name }}
 iface mg-{{ gateway_name }} inet manual
   pre-up ip link add $IFACE type gretap local {{ interface.wan.address.ipv4 | ipaddr('address') }} remote {{ hostvars[gateway_name].interface.wan.address.ipv4 | ipaddr('address') }} dev {{ interface.wan.name }}
+  pre-up ip link set dev $IFACE address {{ interface.batman.mac }}
   pre-up ip link set $IFACE up
   post-up /usr/sbin/batctl -m bat-{{ site.code }} if add $IFACE ||:
   pre-down /usr/sbin/batctl -m bat-{{ site.code }} if del $IFACE ||:

--- a/roles/mesh_gre/templates/etc/network/interfaces.d/mesh_gre.j2
+++ b/roles/mesh_gre/templates/etc/network/interfaces.d/mesh_gre.j2
@@ -3,7 +3,7 @@
 
 auto mg-{{ gateway_name }}
 iface mg-{{ gateway_name }} inet manual
-  pre-up ip link add $IFACE type gretap local {{ interface.wan.address.ipv4 | ipaddr('address') }} remote {{ hostvars[gateway_name].interface.wan.address.ipv4 | ipaddr('address') }} dev {{ interface.wan.name }}
+  pre-up ip link add $IFACE type gretap local {{ interface.wan.address.ipv4 | ipaddr('address') }} remote {{ hostvars[gateway_name].interface.wan.address.nat | default(hostvars[gateway_name].interface.wan.address.ipv4) | ipaddr('address') }} dev {{ interface.wan.name }}
   pre-up ip link set dev $IFACE address {{ interface.batman.mac }}
   pre-up ip link set $IFACE up
   post-up /usr/sbin/batctl -m bat-{{ site.code }} if add $IFACE ||:


### PR DESCRIPTION
Utilize gretap links on the backbone layer. By using gre
instead of fastd traffic transit inside the backbone layer
don't traverse multiple times through fastd, hence use less
cpu cycles and on top we are able to measure inter backbone
traffic easily.